### PR TITLE
Update RBAC allow ingress resource tracking

### DIFF
--- a/k8s-daemonset/k8s/linkerd-rbac-beta.yml
+++ b/k8s-daemonset/k8s/linkerd-rbac-beta.yml
@@ -9,6 +9,9 @@ rules:
   - apiGroups: [""] # "" indicates the core API group
     resources: ["endpoints", "services", "pods"] # pod access is required for the *-legacy.yml examples in this folder
     verbs: ["get", "watch", "list"]
+  - apiGroups: [ "extensions" ]
+    resources: [ "ingresses" ]
+    verbs: ["get", "watch", "list"]
 ---
 # grant namerd permissions to custom resource definitions in k8s 1.8+ and third party resources in k8s < 1.8 for dtab storage
 kind: ClusterRole


### PR DESCRIPTION
Ingress controller example requires access to the Ingress resources.